### PR TITLE
fixed:waitGroup data race

### DIFF
--- a/workpool/workpool.go
+++ b/workpool/workpool.go
@@ -20,7 +20,7 @@ func New(max int) *WorkPool { // 注册工作池，并设置最大并发数
 		errChan:      make(chan error, 1),
 		waitingQueue: myqueue.New(),
 	}
-
+	p.wg.Add(max) // Maximum number of work cycles,最大的工作协程数
 	go p.loop(max)
 	return p
 }
@@ -127,7 +127,6 @@ func (p *WorkPool) waitTask() {
 func (p *WorkPool) loop(maxWorkersCount int) {
 	go p.startQueue() // Startup queue , 启动队列
 
-	p.wg.Add(maxWorkersCount) // Maximum number of work cycles,最大的工作协程数
 	// Start Max workers, 启动max个worker
 	for i := 0; i < maxWorkersCount; i++ {
 		go func() {


### PR DESCRIPTION
I found a data race issue when I run 

 go run -race  main.go

I got the data race problem as the picture showing

<img width="512" alt="datarace" src="https://github.com/user-attachments/assets/72b6656d-80f9-432a-8c4c-5e11b57a97ee">

 
 My main.go code as following (same as the Example in readme.md )
 
 package main

import (
	"fmt"
	"time"

	"github.com/xxjwxc/gowp/workpool"
)

func main() {
	wp := workpool.New(10)     // Set the maximum number of threads
	for i := 0; i < 20; i++ { // Open 20 requests 
		ii := i
		wp.Do(func() error {
			for j := 0; j < 10; j++ { // 0-10 values per print
				fmt.Println(fmt.Sprintf("%v->\t%v", ii, j))
				time.Sleep(1 * time.Second)
			}
			//time.Sleep(1 * time.Second)
			return nil
		})
	}

	wp.Wait()
	fmt.Println("down")
}

What causes the Issue is we use p.wg.Add(maxWorkersCount) in a goroutine,we can move it in New(max int)  so that avoid the data race.
 
 